### PR TITLE
feat: Add multitargets option

### DIFF
--- a/bin/downsample_and_split.R
+++ b/bin/downsample_and_split.R
@@ -13,7 +13,7 @@ species <- args[4]
 n_cells <- as.integer(args[5])
 
 targets <- readLines(targets)
-target <- targets[1]
+target <- strsplit(targets[1], split = ";")[[1]]
 
 if (seuratObj == 'AML_object.rda') {
     load(seuratObj)

--- a/bin/downsample_and_split.R
+++ b/bin/downsample_and_split.R
@@ -15,6 +15,8 @@ n_cells <- as.integer(args[5])
 targets <- readLines(targets)
 target <- strsplit(targets[1], split = ";")[[1]]
 
+targets <- unlist(strsplit(targets, split = ";"))
+
 if (seuratObj == 'AML_object.rda') {
     load(seuratObj)
     seuratObj <- seuratObj[c(VariableFeatures(seuratObj)[1:200], target),]

--- a/bin/merge_and_downstream.R
+++ b/bin/merge_and_downstream.R
@@ -15,7 +15,7 @@ rds_files <- args[5:length(args)]
 
 cell_types <- sub("_weight.*", "", basename(rds_files))
 targets <- readLines(targets)
-target <- targets[1]
+target <- strsplit(targets[1], split = ";")[[1]]
 
 sc_objs <- lapply(rds_files, readRDS)
 
@@ -44,6 +44,8 @@ all_ranks <- data.frame()
 for (target_sc in targets) {
   message("Processing target: ", target_sc)
   
+  target_sc <- strsplit(target_sc, split = ";")[[1]]
+
   # Set the target
   obj@para$target <- target_sc
   

--- a/bin/scrank.R
+++ b/bin/scrank.R
@@ -25,7 +25,7 @@ obj <- CreateScRank(input = sc_obj,
                     cell_type = column,
                     target = target)
 
-obj <- Constr_net(obj, n_cores = n_cores)
+obj <- Constr_net(obj, n.core = n_cores)
 
 weight <- obj@net[cell_type][[1]]
 

--- a/bin/scrank.R
+++ b/bin/scrank.R
@@ -25,7 +25,7 @@ obj <- CreateScRank(input = sc_obj,
                     cell_type = column,
                     target = target)
 
-obj <- Constr_net(obj)
+obj <- Constr_net(obj, n_cores = n_cores)
 
 weight <- obj@net[cell_type][[1]]
 


### PR DESCRIPTION
## Description

We want to add 2 targets as a perturbation. It was added a conditional split for targets with
";", so for example, when you add: "geneA;geneB", it will automatically split to c("geneA", "geneB").

## Test

1) Run a test with two targets splitting by `;`